### PR TITLE
Changes to integrate token and cost metrics into pipeline

### DIFF
--- a/src/metabeeai/metabeeai_llm/json_multistage_qa.py
+++ b/src/metabeeai/metabeeai_llm/json_multistage_qa.py
@@ -458,12 +458,15 @@ def get_api_usage(response, model: str) -> dict:
         logger.info("LiteLLM not installed, falling back to manual pricing for cost calculation.")
     
     except Exception as e:
-        # Catch unexpected errors from LiteLLM (eg. catalogue structure changes, model not found in catalogue etc.), log the info and pass to the manual fallback
+        # Catch unexpected errors from LiteLLM (eg. catalogue structure 
+        # changes, model not found in catalogue etc.), log the info
+        # Pass to the manual fallback
         # Note: This log is suppressed during runs with llm_pipeline.py. The pass will be silent
         logger.warning(f"Error pulling costs from LiteLLM: {e}. Falling back to manual pricing for cost calculation.")
 
     # Second Pricing Attempt: Manual fallback pricing for specific models
-    # Used when LiteLLM doesn't have the model in its pricing catalogue, or if there was an error pulling the costs (eg. LiteLLM not installed or crashed)
+    # Used when LiteLLM doesn't have the model in its pricing catalogue
+    # #or if there was an error pulling the costs (eg. LiteLLM not installed or crashed)
     # Add models manually as needed. Rates divided by 1,000,000 since prices are typically listed as 'per 1M tokens'
     # GPT-4 models
     if model_name == "gpt-4o-mini":
@@ -906,7 +909,13 @@ async def query_all_chunks(
                 # Mark chunk as failed on error
                 batch[i]["answer"] = {"answer": "Error occurred during answer generation", "reason": f"Error: {str(result)}"}
                 # Attach an empty receipt so the token aggregation doesn't have issues with a missing key
-                batch[i]["usage_details"] = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": selected_model}
+                batch[i]["usage_details"] = {
+                    "cost": 0.0, 
+                    "input_tokens": 0, 
+                    "cached_tokens": 0, 
+                    "output_tokens": 0, 
+                    "model": selected_model
+                    }
                 # Add the failed chunk to the array so costs aren't dropped
                 all_answered_chunks.append(batch[i])
             else:

--- a/src/metabeeai/metabeeai_llm/json_multistage_qa.py
+++ b/src/metabeeai/metabeeai_llm/json_multistage_qa.py
@@ -372,6 +372,7 @@ def assess_answer_quality(question: str, chunks: List[Dict[str, Any]], final_ans
 
     return quality_metrics
 
+
 def value_extract(obj, key, default=0):
     """
     Safely extracts a value whether the object is a dictionary or an object.
@@ -382,6 +383,7 @@ def value_extract(obj, key, default=0):
         return obj.get(key, default)
     return getattr(obj, key, default)
 
+
 def get_api_usage(response, model: str) -> dict:
     """
     Extracts token counts from the response and calculates costs.
@@ -390,13 +392,7 @@ def get_api_usage(response, model: str) -> dict:
     If the model isn't present in either, it returns zero cost and the token counts.
     """
     # Initialise a usage dictionary to hold the token counts and cost (zero as default)
-    usage_info = {
-        "cost": 0.0,
-        "input_tokens": 0,
-        "cached_tokens": 0,
-        "output_tokens": 0,
-        "model": model
-    }
+    usage_info = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
 
     # Safety check - extract usage object safely whether it's a dict or an object
     usage_obj = value_extract(response, "usage", None)
@@ -406,7 +402,7 @@ def get_api_usage(response, model: str) -> dict:
     # Cleanly extract token counts using the value_extract helper function
     total_prompt_tokens = value_extract(usage_obj, "prompt_tokens")
     completion_tokens = value_extract(usage_obj, "completion_tokens")
-    
+
     # Normalise the model name (removes "openai/" prefix and converts to lowercase) for better matching
     model_name = model.lower().replace("openai/", "").strip()
 
@@ -426,11 +422,12 @@ def get_api_usage(response, model: str) -> dict:
     # Attempt to pull the per-token costs from LiteLLM's pricing catalogue for the specific model used in this API call
     try:
         import litellm
-        
+
         # Determine which key to look up in the catalogue
         catalogue_key = model
-        
-        # First check if the full model name exists in LiteLLM's pricing catalogue, if it doesn't check the normalised/stripped model name (without "openai/" prefix)
+
+        # First check if the full model name exists in LiteLLM's pricing catalogue
+        # If it doesn't, check the normalised/stripped model name (without "openai/" prefix)
         if catalogue_key not in litellm.model_cost and model_name in litellm.model_cost:
             catalogue_key = model_name
 
@@ -442,23 +439,23 @@ def get_api_usage(response, model: str) -> dict:
             out_rate = catalogue.get("output_cost_per_token", 0.0)
             # If there's no separate cache rate, assume they are the same as normal input tokens
             cache_rate = catalogue.get("cache_read_input_token_cost", in_rate)
-            
+
             # Calculate the breakdown using LiteLLM's pulled rates - multiply the token counts by the retrieved rates
             litellm_in_cost = (uncached_input_tokens * in_rate) + (cached_tokens * cache_rate)
             litellm_out_cost = completion_tokens * out_rate
             litellm_total = litellm_in_cost + litellm_out_cost
 
-            #Save the cost and return the usage info (skipping the manual fallback below)
+            # Save the cost and return the usage info (skipping the manual fallback below)
             usage_info["cost"] = litellm_total
             return usage_info
-                
+
     except ImportError:
         # If LiteLLM isn't installed, log the info and pass to the manual fallback
         # Note: This log is suppressed during runs with llm_pipeline.py. The pass will be silent
         logger.info("LiteLLM not installed, falling back to manual pricing for cost calculation.")
-    
+
     except Exception as e:
-        # Catch unexpected errors from LiteLLM (eg. catalogue structure 
+        # Catch unexpected errors from LiteLLM (eg. catalogue structure
         # changes, model not found in catalogue etc.), log the info
         # Pass to the manual fallback
         # Note: This log is suppressed during runs with llm_pipeline.py. The pass will be silent
@@ -472,28 +469,28 @@ def get_api_usage(response, model: str) -> dict:
     if model_name == "gpt-4o-mini":
         input_cost = (uncached_input_tokens * 0.15 / 1000000) + (cached_tokens * 0.075 / 1000000)
         output_cost = completion_tokens * 0.60 / 1000000
-           
+
     elif model_name == "gpt-4o":
         input_cost = (uncached_input_tokens * 2.50 / 1000000) + (cached_tokens * 1.25 / 1000000)
         output_cost = completion_tokens * 10.00 / 1000000
-        
+
     # GPT-5 models
     elif model_name == "gpt-5-nano":
         input_cost = (uncached_input_tokens * 0.05 / 1000000) + (cached_tokens * 0.005 / 1000000)
         output_cost = completion_tokens * 0.40 / 1000000
-        
+
     elif model_name == "gpt-5-mini":
         input_cost = (uncached_input_tokens * 0.25 / 1000000) + (cached_tokens * 0.025 / 1000000)
         output_cost = completion_tokens * 2.00 / 1000000
-     
+
     elif model_name == "gpt-5":
         input_cost = (uncached_input_tokens * 1.25 / 1000000) + (cached_tokens * 0.125 / 1000000)
         output_cost = completion_tokens * 10.00 / 1000000
-        
+
     elif model_name == "gpt-5.1":
         input_cost = (uncached_input_tokens * 1.25 / 1000000) + (cached_tokens * 0.125 / 1000000)
         output_cost = completion_tokens * 10.00 / 1000000
-        
+
     else:
         # Safety net for unknown models - returns zero cost
         input_cost = 0.0
@@ -502,7 +499,7 @@ def get_api_usage(response, model: str) -> dict:
     # Combine input and output costs and return the final dictionary
     usage_info["cost"] = input_cost + output_cost
     return usage_info
-    
+
 
 # --------------------------------------------------------------------------
 # Asynchronous Processing Functions
@@ -541,7 +538,7 @@ Return the entities in a list format.
     messages = [{"content": prompt, "role": "user"}]
 
     result = None
-    
+
     # Set up a cumulative usage dictionary to track total costs and token counts across retries
     cumulative_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
 
@@ -549,7 +546,7 @@ Return the entities in a list format.
         try:
             # Call the API asynchronously expecting a response conforming to the Answer model.
             response = await acompletion(model=model, messages=messages, response_format=AnswerList, temperature=0)
-            
+
             # Get the API usage for this response and accumulate the usage across retries
             current_usage = get_api_usage(response, model)
             cumulative_usage["cost"] += current_usage["cost"]
@@ -565,16 +562,16 @@ Return the entities in a list format.
             logger.error("Error obtaining answer restructuring", e)
             time.sleep(1)
             continue
-            
+
     # Safety fallback in case the API completely failed to return valid JSON across all retries
     # Trying to attach the cost data to 'none' in the next step will give TypeError and crash the pipeline otherwise
     if result is None:
         result = {"answer": []}
-        
+
     # Attach the cumulative cost and usage details to the result object
     result["cost"] = cumulative_usage["cost"]
     result["usage_details"] = cumulative_usage
-    
+
     return result
 
 
@@ -646,14 +643,14 @@ async def get_answer(question: str, chunk: Dict[str, Any], model: str = ANSWER_M
         try:
             # Call the API asynchronously expecting a response conforming to the Answer model.
             response = await acompletion(model=model, messages=messages, response_format=Answer, temperature=0)
-            
+
             # Get the API usage for this response and accumulate the usage across retries
             current_usage = get_api_usage(response, model)
             cumulative_usage["cost"] += current_usage["cost"]
             cumulative_usage["input_tokens"] += current_usage["input_tokens"]
             cumulative_usage["cached_tokens"] += current_usage["cached_tokens"]
             cumulative_usage["output_tokens"] += current_usage["output_tokens"]
-            
+
             # Parse the JSON string from the API response.
             chunk["answer"] = json.loads(response.choices[0].message.content)
             logger.info("Answer obtained for chunk %s: %s", chunk.get("chunk_id"), chunk["answer"])
@@ -743,9 +740,9 @@ async def get_top_relevant_chunks(
         for i, chunk in enumerate(filtered_chunks):
             chunk_text = chunk.get("text", "")[:500]  # Limit text length
             chunk_id = chunk.get("chunk_id", f"chunk_{i}")
-            prompt_parts.append(f"Chunk {i+1} (ID: {chunk_id}): {chunk_text}...")
+            prompt_parts.append(f"Chunk {i + 1} (ID: {chunk_id}): {chunk_text}...")
             # Debug: Log chunk content to see what we're actually working with
-            logger.info(f"DEBUG: Chunk {i+1} content preview: {chunk_text[:100]}...")
+            logger.info(f"DEBUG: Chunk {i + 1} content preview: {chunk_text[:100]}...")
 
         # Build dynamic instructions based on question metadata
         instructions_list = [
@@ -760,7 +757,7 @@ async def get_top_relevant_chunks(
             instructions_list.insert(1, f"2. Follow these specific guidelines: {'; '.join(question_metadata['instructions'])}")
             # Renumber the remaining instructions
             for i in range(2, len(instructions_list)):
-                instructions_list[i] = f"{i+2}. {instructions_list[i].split('. ', 1)[1]}"
+                instructions_list[i] = f"{i + 2}. {instructions_list[i].split('. ', 1)[1]}"
 
         prompt_parts.extend(
             [
@@ -806,7 +803,7 @@ async def get_top_relevant_chunks(
                     if 0 <= idx < len(filtered_chunks):
                         selected_chunks.append(filtered_chunks[idx])
                         logger.info(
-                            f"DEBUG: Selected chunk {idx+1}: {filtered_chunks[idx].get('chunk_id')} - "
+                            f"DEBUG: Selected chunk {idx + 1}: {filtered_chunks[idx].get('chunk_id')} - "
                             f"Content: {filtered_chunks[idx].get('text', '')[:100]}..."
                         )
 
@@ -910,12 +907,12 @@ async def query_all_chunks(
                 batch[i]["answer"] = {"answer": "Error occurred during answer generation", "reason": f"Error: {str(result)}"}
                 # Attach an empty receipt so the token aggregation doesn't have issues with a missing key
                 batch[i]["usage_details"] = {
-                    "cost": 0.0, 
-                    "input_tokens": 0, 
-                    "cached_tokens": 0, 
-                    "output_tokens": 0, 
-                    "model": selected_model
-                    }
+                    "cost": 0.0,
+                    "input_tokens": 0,
+                    "cached_tokens": 0,
+                    "output_tokens": 0,
+                    "model": selected_model,
+                }
                 # Add the failed chunk to the array so costs aren't dropped
                 all_answered_chunks.append(batch[i])
             else:
@@ -947,12 +944,12 @@ async def reflect_answers(question: str, chunks: List[Dict[str, Any]], model: st
 
     formatted_chunks: str = "\n".join(
         f"""
-<Reference text chunk_id:{chunk.get('chunk_id', 'N/A')}>
-{chunk.get('text', '')}
-</Reference text chunk_id:{chunk.get('chunk_id', 'N/A')}>
-<Answer chunk_id:{chunk.get('chunk_id', 'N/A')}>
-{chunk.get('answer', '')}
-</Answer chunk_id:{chunk.get('chunk_id', 'N/A')}>
+<Reference text chunk_id:{chunk.get("chunk_id", "N/A")}>
+{chunk.get("text", "")}
+</Reference text chunk_id:{chunk.get("chunk_id", "N/A")}>
+<Answer chunk_id:{chunk.get("chunk_id", "N/A")}>
+{chunk.get("answer", "")}
+</Answer chunk_id:{chunk.get("chunk_id", "N/A")}>
         """.strip()
         for chunk in chunks
     )
@@ -1000,41 +997,40 @@ async def reflect_answers(question: str, chunks: List[Dict[str, Any]], model: st
 
     messages = [{"content": prompt, "role": "user"}]
 
-
     # Set up a cumulative usage dictionary to track total costs and token counts across retries
     cumulative_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
 
     for i in range(RETRY):
         try:
             response = await acompletion(model=model, messages=messages, response_format=AnswerWithChunkId, temperature=0)
-            
+
             # Get the API usage for this response and accumulate the usage across retries
             current_usage = get_api_usage(response, model)
             cumulative_usage["cost"] += current_usage["cost"]
             cumulative_usage["input_tokens"] += current_usage["input_tokens"]
             cumulative_usage["cached_tokens"] += current_usage["cached_tokens"]
             cumulative_usage["output_tokens"] += current_usage["output_tokens"]
-            
+
             result = json.loads(response.choices[0].message.content)
-            
+
             # Attach the cumulative usage here since the function returns on success
             result["cost"] = cumulative_usage["cost"]
             result["usage_details"] = cumulative_usage
-            
+
             logger.info("Reflected answer: %s", result)
             return result
         except Exception as e:
             logger.error("Error reflecting answers: %s", e)
             time.sleep(1)
-            
+
     # Fallback response if the model completely fails to generate valid JSON after all retries
-    # Added to still attach the cumulative usage here, so the costs of the failed attempts aren't dropped 
+    # Added to still attach the cumulative usage here, so the costs of the failed attempts aren't dropped
     fallback_result = {
-        "answer": "INSUFFICIENT_INFO", 
+        "answer": "INSUFFICIENT_INFO",
         "reason": "Failed to generate reflection after multiple attempts.",
         "chunk_ids": [],
         "cost": cumulative_usage["cost"],
-        "usage_details": cumulative_usage
+        "usage_details": cumulative_usage,
     }
     return fallback_result
 
@@ -1164,7 +1160,7 @@ async def ask_json(
     # Step 2: Filter out irrelevant chunks with question-specific settings.
     # Use parallel processing with optimized batch sizes
     relevance_batch_size = min(DEFAULT_RELEVANCE_BATCH_SIZE, len(chunks), MAX_CONCURRENT_REQUESTS)
-    
+
     # Call the function to retrieve relevant chunks. It returns the token usage and the chunks
     relevant_chunks, filter_usage = await filter_all_chunks(
         question, chunks, question_config["max_chunks"], batch_size=relevance_batch_size, model=selected_relevance_model
@@ -1172,7 +1168,7 @@ async def ask_json(
 
     # Initialise an empty dictionary to keep track of the total metrics across the whole pipeline run
     metrics = {}
-    
+
     def add_usage(usage, phase):
         """
         Helper function to add usage data to the main 'metrics' dictionary.
@@ -1220,7 +1216,7 @@ async def ask_json(
     logger.info(f"Found {len(relevant_chunks)} relevant chunks:")
     for i, chunk in enumerate(relevant_chunks):
         chunk_id = chunk.get("chunk_id", "N/A")
-        logger.info(f"  Chunk {i+1}: ID {chunk_id}")
+        logger.info(f"  Chunk {i + 1}: ID {chunk_id}")
 
     # Step 2: Query each relevant chunk for its answer.
     # Use parallel processing with optimized batch sizes for answer generation

--- a/src/metabeeai/metabeeai_llm/json_multistage_qa.py
+++ b/src/metabeeai/metabeeai_llm/json_multistage_qa.py
@@ -372,6 +372,134 @@ def assess_answer_quality(question: str, chunks: List[Dict[str, Any]], final_ans
 
     return quality_metrics
 
+def value_extract(obj, key, default=0):
+    """
+    Safely extracts a value whether the object is a dictionary or an object.
+    """
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+def get_api_usage(response, model: str) -> dict:
+    """
+    Extracts token counts from the response and calculates costs.
+    Pulls per-token costs from LiteLLM's catalogue to show the cost breakdown.
+    If LiteLLM fails or doesn't recognise the model, it falls back to the manually defined model costs.
+    If the model isn't present in either, it returns zero cost and the token counts.
+    """
+    # Initialise a usage dictionary to hold the token counts and cost (zero as default)
+    usage_info = {
+        "cost": 0.0,
+        "input_tokens": 0,
+        "cached_tokens": 0,
+        "output_tokens": 0,
+        "model": model
+    }
+
+    # Safety check - extract usage object safely whether it's a dict or an object
+    usage_obj = value_extract(response, "usage", None)
+    if not usage_obj:
+        return usage_info
+
+    # Cleanly extract token counts using the value_extract helper function
+    total_prompt_tokens = value_extract(usage_obj, "prompt_tokens")
+    completion_tokens = value_extract(usage_obj, "completion_tokens")
+    
+    # Normalise the model name (removes "openai/" prefix and converts to lowercase) for better matching
+    model_name = model.lower().replace("openai/", "").strip()
+
+    # Safely extract cached tokens
+    details = value_extract(usage_obj, "prompt_tokens_details", None)
+    cached_tokens = value_extract(details, "cached_tokens") if details else 0
+
+    # Calculate normal input tokens by subtracting cached tokens from total prompt tokens
+    uncached_input_tokens = max(0, total_prompt_tokens - cached_tokens)
+
+    # Store the calculated token values in the dictionary
+    usage_info["input_tokens"] = uncached_input_tokens
+    usage_info["cached_tokens"] = cached_tokens
+    usage_info["output_tokens"] = completion_tokens
+
+    # First Pricing Attempt: LiteLLM automatic pricing
+    # Attempt to pull the per-token costs from LiteLLM's pricing catalogue for the specific model used in this API call
+    try:
+        import litellm
+        
+        # Determine which key to look up in the catalogue
+        catalogue_key = model
+        
+        # First check if the full model name exists in LiteLLM's pricing catalogue, if it doesn't check the normalised/stripped model name (without "openai/" prefix)
+        if catalogue_key not in litellm.model_cost and model_name in litellm.model_cost:
+            catalogue_key = model_name
+
+        # If the model is found in the catalogue, pull the relevant token rates
+        if catalogue_key in litellm.model_cost:
+            catalogue = litellm.model_cost[catalogue_key]
+
+            in_rate = catalogue.get("input_cost_per_token", 0.0)
+            out_rate = catalogue.get("output_cost_per_token", 0.0)
+            # If there's no separate cache rate, assume they are the same as normal input tokens
+            cache_rate = catalogue.get("cache_read_input_token_cost", in_rate)
+            
+            # Calculate the breakdown using LiteLLM's pulled rates - multiply the token counts by the retrieved rates
+            litellm_in_cost = (uncached_input_tokens * in_rate) + (cached_tokens * cache_rate)
+            litellm_out_cost = completion_tokens * out_rate
+            litellm_total = litellm_in_cost + litellm_out_cost
+
+            #Save the cost and return the usage info (skipping the manual fallback below)
+            usage_info["cost"] = litellm_total
+            return usage_info
+                
+    except ImportError:
+        # If LiteLLM isn't installed, log the info and pass to the manual fallback
+        # Note: This log is suppressed during runs with llm_pipeline.py. The pass will be silent
+        logger.info("LiteLLM not installed, falling back to manual pricing for cost calculation.")
+    
+    except Exception as e:
+        # Catch unexpected errors from LiteLLM (eg. catalogue structure changes, model not found in catalogue etc.), log the info and pass to the manual fallback
+        # Note: This log is suppressed during runs with llm_pipeline.py. The pass will be silent
+        logger.warning(f"Error pulling costs from LiteLLM: {e}. Falling back to manual pricing for cost calculation.")
+
+    # Second Pricing Attempt: Manual fallback pricing for specific models
+    # Used when LiteLLM doesn't have the model in its pricing catalogue, or if there was an error pulling the costs (eg. LiteLLM not installed or crashed)
+    # Add models manually as needed. Rates divided by 1,000,000 since prices are typically listed as 'per 1M tokens'
+    # GPT-4 models
+    if model_name == "gpt-4o-mini":
+        input_cost = (uncached_input_tokens * 0.15 / 1000000) + (cached_tokens * 0.075 / 1000000)
+        output_cost = completion_tokens * 0.60 / 1000000
+           
+    elif model_name == "gpt-4o":
+        input_cost = (uncached_input_tokens * 2.50 / 1000000) + (cached_tokens * 1.25 / 1000000)
+        output_cost = completion_tokens * 10.00 / 1000000
+        
+    # GPT-5 models
+    elif model_name == "gpt-5-nano":
+        input_cost = (uncached_input_tokens * 0.05 / 1000000) + (cached_tokens * 0.005 / 1000000)
+        output_cost = completion_tokens * 0.40 / 1000000
+        
+    elif model_name == "gpt-5-mini":
+        input_cost = (uncached_input_tokens * 0.25 / 1000000) + (cached_tokens * 0.025 / 1000000)
+        output_cost = completion_tokens * 2.00 / 1000000
+     
+    elif model_name == "gpt-5":
+        input_cost = (uncached_input_tokens * 1.25 / 1000000) + (cached_tokens * 0.125 / 1000000)
+        output_cost = completion_tokens * 10.00 / 1000000
+        
+    elif model_name == "gpt-5.1":
+        input_cost = (uncached_input_tokens * 1.25 / 1000000) + (cached_tokens * 0.125 / 1000000)
+        output_cost = completion_tokens * 10.00 / 1000000
+        
+    else:
+        # Safety net for unknown models - returns zero cost
+        input_cost = 0.0
+        output_cost = 0.0
+
+    # Combine input and output costs and return the final dictionary
+    usage_info["cost"] = input_cost + output_cost
+    return usage_info
+    
 
 # --------------------------------------------------------------------------
 # Asynchronous Processing Functions
@@ -410,10 +538,22 @@ Return the entities in a list format.
     messages = [{"content": prompt, "role": "user"}]
 
     result = None
+    
+    # Set up a cumulative usage dictionary to track total costs and token counts across retries
+    cumulative_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
+
     for i in range(RETRY):
         try:
             # Call the API asynchronously expecting a response conforming to the Answer model.
             response = await acompletion(model=model, messages=messages, response_format=AnswerList, temperature=0)
+            
+            # Get the API usage for this response and accumulate the usage across retries
+            current_usage = get_api_usage(response, model)
+            cumulative_usage["cost"] += current_usage["cost"]
+            cumulative_usage["input_tokens"] += current_usage["input_tokens"]
+            cumulative_usage["cached_tokens"] += current_usage["cached_tokens"]
+            cumulative_usage["output_tokens"] += current_usage["output_tokens"]
+
             # Parse the JSON string from the API response.
             result = json.loads(response.choices[0].message.content)
             logger.info("Answer restructured", result)
@@ -422,6 +562,16 @@ Return the entities in a list format.
             logger.error("Error obtaining answer restructuring", e)
             time.sleep(1)
             continue
+            
+    # Safety fallback in case the API completely failed to return valid JSON across all retries
+    # Trying to attach the cost data to 'none' in the next step will give TypeError and crash the pipeline otherwise
+    if result is None:
+        result = {"answer": []}
+        
+    # Attach the cumulative cost and usage details to the result object
+    result["cost"] = cumulative_usage["cost"]
+    result["usage_details"] = cumulative_usage
+    
     return result
 
 
@@ -486,10 +636,21 @@ async def get_answer(question: str, chunk: Dict[str, Any], model: str = ANSWER_M
 
     messages = [{"content": prompt, "role": "user"}]
 
+    # Set up a cumulative usage dictionary to track total costs and token counts across retries
+    cumulative_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
+
     for i in range(RETRY):
         try:
             # Call the API asynchronously expecting a response conforming to the Answer model.
             response = await acompletion(model=model, messages=messages, response_format=Answer, temperature=0)
+            
+            # Get the API usage for this response and accumulate the usage across retries
+            current_usage = get_api_usage(response, model)
+            cumulative_usage["cost"] += current_usage["cost"]
+            cumulative_usage["input_tokens"] += current_usage["input_tokens"]
+            cumulative_usage["cached_tokens"] += current_usage["cached_tokens"]
+            cumulative_usage["output_tokens"] += current_usage["output_tokens"]
+            
             # Parse the JSON string from the API response.
             chunk["answer"] = json.loads(response.choices[0].message.content)
             logger.info("Answer obtained for chunk %s: %s", chunk.get("chunk_id"), chunk["answer"])
@@ -499,6 +660,11 @@ async def get_answer(question: str, chunk: Dict[str, Any], model: str = ANSWER_M
             chunk["answer"] = None  # In case of error, mark answer as None.
             time.sleep(1)
             continue
+
+    # Attach the cumulative cost and usage details to the chunk
+    chunk["cost"] = cumulative_usage["cost"]
+    chunk["usage_details"] = cumulative_usage
+
     return chunk
 
 
@@ -546,7 +712,9 @@ async def get_top_relevant_chunks(
             filtered_chunks.append(chunk)
 
         if not filtered_chunks:
-            return []
+            # Return an empty list and an empty usage dictionary
+            empty_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
+            return [], empty_usage
 
         # Build the prompt for chunk selection
         prompt_parts = [
@@ -613,6 +781,8 @@ async def get_top_relevant_chunks(
         ]
 
         response = await acompletion(model=model, messages=messages, temperature=0)
+        # Pass the API response and the model name to the get_api_usage helper function
+        usage = get_api_usage(response, model)
 
         if response and hasattr(response, "choices") and response.choices:
             result = response.choices[0].message.content
@@ -638,21 +808,23 @@ async def get_top_relevant_chunks(
                         )
 
                 logger.info(f"Selected {len(selected_chunks)} chunks from {len(filtered_chunks)} total chunks")
-                return selected_chunks
+                return selected_chunks, usage
 
             except Exception as e:
                 logger.error(f"Error parsing chunk selection response: {e}")
                 # Fallback: return first few chunks
-                return filtered_chunks[:max_chunks]
+                return filtered_chunks[:max_chunks], usage
         else:
             logger.error("No valid response from LLM for chunk selection")
             # Fallback: return first few chunks
-            return filtered_chunks[:max_chunks]
+            return filtered_chunks[:max_chunks], usage
 
     except Exception as e:
         logger.error(f"Error selecting top chunks: {e}")
         # Fallback: return first few chunks
-        return chunks[:max_chunks]
+        # Create a usage dictionary with zeros so that if the LLM doesn't select chunks, the program doesn't break
+        empty_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
+        return chunks[:max_chunks], empty_usage
 
 
 async def filter_all_chunks(
@@ -672,7 +844,10 @@ async def filter_all_chunks(
         List[Dict[str, Any]]: List of top relevant chunks.
     """
     if not chunks:
-        return []
+        # Return an empty list and an empty usage dictionary
+        selected_model = model if model else RELEVANCE_MODEL
+        empty_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": selected_model}
+        return [], empty_usage
 
     # Get question metadata for the prompt
     question_metadata = get_question_metadata(question)
@@ -681,12 +856,12 @@ async def filter_all_chunks(
 
     # Use the new simplified approach
     selected_model = model if model else RELEVANCE_MODEL
-    relevant_chunks = await get_top_relevant_chunks(
+    relevant_chunks, usage = await get_top_relevant_chunks(
         chunks=chunks, question=question, question_metadata=question_metadata, max_chunks=max_chunks, model=selected_model
     )
 
     logger.info(f"Selected {len(relevant_chunks)} relevant chunks")
-    return relevant_chunks
+    return relevant_chunks, usage
 
 
 async def query_all_chunks(
@@ -730,6 +905,10 @@ async def query_all_chunks(
                 logger.error(f"Error generating answer for chunk in batch {batch_idx + 1}: {result}")
                 # Mark chunk as failed on error
                 batch[i]["answer"] = {"answer": "Error occurred during answer generation", "reason": f"Error: {str(result)}"}
+                # Attach an empty receipt so the token aggregation doesn't have issues with a missing key
+                batch[i]["usage_details"] = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": selected_model}
+                # Add the failed chunk to the array so costs aren't dropped
+                all_answered_chunks.append(batch[i])
             else:
                 all_answered_chunks.append(result)
 
@@ -812,15 +991,43 @@ async def reflect_answers(question: str, chunks: List[Dict[str, Any]], model: st
 
     messages = [{"content": prompt, "role": "user"}]
 
+
+    # Set up a cumulative usage dictionary to track total costs and token counts across retries
+    cumulative_usage = {"cost": 0.0, "input_tokens": 0, "cached_tokens": 0, "output_tokens": 0, "model": model}
+
     for i in range(RETRY):
         try:
             response = await acompletion(model=model, messages=messages, response_format=AnswerWithChunkId, temperature=0)
+            
+            # Get the API usage for this response and accumulate the usage across retries
+            current_usage = get_api_usage(response, model)
+            cumulative_usage["cost"] += current_usage["cost"]
+            cumulative_usage["input_tokens"] += current_usage["input_tokens"]
+            cumulative_usage["cached_tokens"] += current_usage["cached_tokens"]
+            cumulative_usage["output_tokens"] += current_usage["output_tokens"]
+            
             result = json.loads(response.choices[0].message.content)
+            
+            # Attach the cumulative usage here since the function returns on success
+            result["cost"] = cumulative_usage["cost"]
+            result["usage_details"] = cumulative_usage
+            
             logger.info("Reflected answer: %s", result)
             return result
         except Exception as e:
             logger.error("Error reflecting answers: %s", e)
             time.sleep(1)
+            
+    # Fallback response if the model completely fails to generate valid JSON after all retries
+    # Added to still attach the cumulative usage here, so the costs of the failed attempts aren't dropped 
+    fallback_result = {
+        "answer": "INSUFFICIENT_INFO", 
+        "reason": "Failed to generate reflection after multiple attempts.",
+        "chunk_ids": [],
+        "cost": cumulative_usage["cost"],
+        "usage_details": cumulative_usage
+    }
+    return fallback_result
 
 
 # --------------------------------------------------------------------------
@@ -948,16 +1155,44 @@ async def ask_json(
     # Step 2: Filter out irrelevant chunks with question-specific settings.
     # Use parallel processing with optimized batch sizes
     relevance_batch_size = min(DEFAULT_RELEVANCE_BATCH_SIZE, len(chunks), MAX_CONCURRENT_REQUESTS)
-    relevant_chunks: List[Dict[str, Any]] = await filter_all_chunks(
+    
+    # Call the function to retrieve relevant chunks. It returns the token usage and the chunks
+    relevant_chunks, filter_usage = await filter_all_chunks(
         question, chunks, question_config["max_chunks"], batch_size=relevance_batch_size, model=selected_relevance_model
     )
 
+    # Initialise an empty dictionary to keep track of the total metrics across the whole pipeline run
+    metrics = {}
+    
+    def add_usage(usage, phase):
+        """
+        Helper function to add usage data to the main 'metrics' dictionary.
+        Categorises by phase (Retrieval and Answering) and model name.
+        Sums up the input, cached, and output tokens, as well as the cost for each model used in the process.
+        """
+        model_name = usage.get("model", "unknown")
+        # Create a key for this phase and model combination
+        key = f"{phase}|{model_name}"
+        # If we haven't seen this phase/model combination before, initialise its counters as zero
+        if key not in metrics:
+            metrics[key] = {"input": 0, "cached": 0, "output": 0, "cost": 0.0}
+        metrics[key]["input"] += usage.get("input_tokens", 0)
+        metrics[key]["cached"] += usage.get("cached_tokens", 0)
+        metrics[key]["output"] += usage.get("output_tokens", 0)
+        metrics[key]["cost"] += usage.get("cost", 0.0)
+
     if len(relevant_chunks) == 0:
         logger.info("No relevant chunks found for the question: %s", question)
+        # Track the usage from the filtering stage under the 'Retrieval' category, even if no chunks were found
+        add_usage(filter_usage, "Retrieval")
         return {
             "answer": question_config.get("no_info_response", "Information not found in the provided text."),
             "chunk_ids": [],
             "reason": "No relevant chunks found for the question.",
+            # Pass retrieval cost to the pipeline for logging (will be popped before saving to answers.json)
+            "cost": filter_usage["cost"],
+            # Pass retrieval token metrics to the pipeline for logging (will be popped before saving to answers.json)
+            "metrics": metrics,
             "relevance_info": {
                 "total_chunks_processed": len(chunks),
                 "relevant_chunks_found": 0,
@@ -1021,11 +1256,29 @@ async def ask_json(
             "chunk_ids": [chunk.get("chunk_id", "N/A") for chunk in relevant_chunks],
         }
 
+    # Accumulate metrics before building enhanced_result
+    # Track the cost of the initial filtering/retrieval phase
+    add_usage(filter_usage, "Retrieval")
+    # Loop through every chunk that was individually queried and track its cost under 'Answering'
+    for chunk in answered_chunks:
+        if "usage_details" in chunk:
+            add_usage(chunk["usage_details"], "Answering")
+    # Track the final 'reflection' step cost under 'Answering' too
+    if isinstance(final_result, dict) and "usage_details" in final_result:
+        add_usage(final_result["usage_details"], "Answering")
+
+    # Loop through the aggregated metrics dictionary and sum up the costs to get the final total cost for the whole run
+    total_cost = sum(m["cost"] for m in metrics.values())
+
     # Create the enhanced result with the required structure
     enhanced_result = {
         "answer": final_result.get("answer", ""),
         "reason": final_result.get("reason", ""),
         "chunk_ids": final_result.get("chunk_ids", []),
+        # Pass total question cost to the pipeline for logging (will be popped before saving to answers.json)
+        "cost": total_cost,
+        # Pass aggregated token metrics to the pipeline for logging (will be popped before saving to answers.json)
+        "metrics": metrics,
         # Additional metadata fields
         "relevance_info": {
             "total_chunks_processed": len(chunks),

--- a/src/metabeeai/metabeeai_llm/llm_pipeline.py
+++ b/src/metabeeai/metabeeai_llm/llm_pipeline.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import time
+import copy
 
 import yaml
 
@@ -46,7 +47,9 @@ def _get_questions():
         questions_path = os.path.join(script_dir, "questions.yml")
 
         with open(questions_path, "r") as file:
-            _QUESTIONS = yaml.safe_load(file)
+            # Extract the questions ('QUESTIONS') dictionary to prevent double-wrapping if it exists, otherwise use the whole config as the questions dictionary
+            config = yaml.safe_load(file)
+            _QUESTIONS = config.get("QUESTIONS", config)
 
     return _QUESTIONS
 
@@ -74,6 +77,10 @@ async def get_answer(question_text, json_path, relevance_model=None, answer_mode
             "answer": result.get("answer", ""),
             "reason": result.get("reason", ""),
             "chunk_ids": result.get("chunk_ids", []),
+            # Pass total question cost to the pipeline for logging (will be popped before saving to answers.json)
+            "cost": result.get("cost", 0.0),
+            # Pass aggregated token metrics to the pipeline for logging (will be popped before saving to answers.json)
+            "metrics": result.get("metrics", {})
         }
     else:
         # Fallback if result is not a dict
@@ -81,6 +88,10 @@ async def get_answer(question_text, json_path, relevance_model=None, answer_mode
             "answer": str(result) if result else "",
             "reason": "Answer generated from available information",
             "chunk_ids": [],
+            # Safety fallback - pass zero cost so the logging loop doesn't crash (still popped before saving to answers.json)
+            "cost": 0.0,
+            # Safety fallback - pass empty metrics dictionary so the logging loop doesn't crash (still popped before saving to answers.json)
+            "metrics": {}
         }
 
 
@@ -127,6 +138,34 @@ async def process_question_tree(tree, json_path, context=None, relevance_model=N
                     list_result = await format_to_list_async(question_of_the_list, answer["answer"])
                     list_items = list_result["answer"]
                     result[key] = {}
+                    
+                    # Preserve the parent list costs so extract_metrics can see them
+                    # Sum the costs of both finding the list and formatting it into an array
+                    total_list_cost = answer.get("cost", 0.0) + list_result.get("cost", 0.0)
+                    
+                    # Copy the original list token metrics into the combined run metrics tracker
+                    combined_metrics = copy.deepcopy(answer.get("metrics", {}))
+                    if list_result and "usage_details" in list_result:
+                        usage = list_result["usage_details"]
+                        m_name = usage.get("model", "unknown")
+                        metric_key = f"Answering|{m_name}"
+                        
+                        # Initialise counters for the model if it's the first time seeing it in this block
+                        if metric_key not in combined_metrics:
+                            combined_metrics[metric_key] = {"input": 0, "cached": 0, "output": 0, "cost": 0.0}
+                        # Add the list formatting token costs to the combined run tracking data
+                        combined_metrics[metric_key]["input"] += usage.get("input_tokens", 0)
+                        combined_metrics[metric_key]["cached"] += usage.get("cached_tokens", 0)
+                        combined_metrics[metric_key]["output"] += usage.get("output_tokens", 0)
+                        combined_metrics[metric_key]["cost"] += usage.get("cost", 0.0)
+
+                    # Store the totals in a dictionary key so they can be processed by the logging function
+                    result[key]["_list_metadata"] = {
+                        "answer": "List discovery metadata",
+                        "cost": total_list_cost,
+                        "metrics": combined_metrics
+                    }
+
                     for item in list_items:
                         new_context = context.copy()
                         new_context[endpoint_name] = item
@@ -206,6 +245,63 @@ def merge_json_in_the_folder(folder_path, overwrite=False):
     with open(folder_path + "merged.json", "w") as f:
         json.dump(json_obj, f, indent=2)
 
+def extract_metrics(answers_dict, prefix=""):
+    """
+    Iterates through the answers dictionary to extract costs and model metrics, removing them from the dictionary.
+    Deletes any temporary tracking keys so they are not in the final JSON.
+    """
+    costs = {}
+    metrics = {}
+    total = 0.0
+    
+    # Handle lists if the top-level question yml is an array
+    if isinstance(answers_dict, list):
+        for i, item in enumerate(answers_dict):
+            if isinstance(item, dict):
+                sub_costs, sub_metrics, sub_total = extract_metrics(item, prefix=f"{prefix}[{i}].")
+                costs.update(sub_costs)
+                metrics.update(sub_metrics)
+                total += sub_total
+        return costs, metrics, total
+
+
+    # Use list() to modify the dictionary while looping
+    for key in list(answers_dict.keys()):
+        value = answers_dict[key]
+
+        if isinstance(value, dict):
+            if "metrics" in value and "answer" in value:
+                # Use pop() to extract the data and delete the keys from the dictionary
+                costs[prefix + key] = value.pop("cost", 0.0)
+                metrics[prefix + key] = value.pop("metrics", {})
+                total += costs[prefix + key]
+            else:
+                # If it's a nested category dictionary, go one layer deeper
+                sub_costs, sub_metrics, sub_total = extract_metrics(value, prefix=f"{prefix}{key}.")
+                
+                # Merge the numbers found in the sub-category into the main tracking dictionaries
+                costs.update(sub_costs)
+                metrics.update(sub_metrics)
+                total += sub_total
+
+            # If it's a hidden overhead key (starts with _), remove the shell from the dictionary
+            if key.startswith("_"):
+                answers_dict.pop(key)
+
+        elif isinstance(value, list):
+            # If the value is a list of sub-questions, loop through the list
+            for i, item in enumerate(value):
+                if isinstance(item, dict):
+                    # Go one layer deeper into the list items
+                    # Adds [i] to the prefix to track which list item the cost belongs to
+                    sub_costs, sub_metrics, sub_total = extract_metrics(item, prefix=f"{prefix}{key}[{i}].")
+                    
+                    # Merge the numbers found in the sub-category into the main tracking dictionaries
+                    costs.update(sub_costs)
+                    metrics.update(sub_metrics)
+                    total += sub_total
+                    
+    return costs, metrics, total
 
 async def process_papers(
     base_dir=None,
@@ -273,7 +369,10 @@ async def process_papers(
     print(f"📁 Papers directory: {base_dir}")
     print(f"📝 Progress log: {log_file}")
     print("=" * 60)
-
+    
+    # Initialise the global metrics dictionary to hold the total token and cost counts across all files in the run
+    global_metrics = {}
+    
     for paper_folder in paper_folders:
         paper_path = os.path.join(base_dir, paper_folder)
 
@@ -355,6 +454,10 @@ async def process_papers(
                         literature_answers[key] = existing_answers[key]
                 print(f"  🔄 Merged answers: {len(literature_answers)} total question(s)")
 
+            # Extract the metrics, removing the tracking data from the dictionary
+            # Happens before saving so the data doesn't get written into answers.json
+            costs, question_metrics, total_cost = extract_metrics(literature_answers)
+
             # Save the merged results in QUESTIONS format
             output_data = {"QUESTIONS": literature_answers}
 
@@ -364,9 +467,29 @@ async def process_papers(
             completed_papers += 1
             print(f"  ✅ Paper {paper_folder} completed successfully")
 
+            # Print and log the metrics
+            log_lines = []
+            for q_key, q_cost in costs.items():
+                # Format individual cost metrics for clear reading in the log file
+                log_lines.append(f"- {q_key}: ${q_cost:.4f}")
+                
+                # Collect token usage totals into global_metrics for the final summary
+                q_m = question_metrics.get(q_key, {})
+                for model_name, tokens in q_m.items():
+                    if model_name not in global_metrics:
+                        global_metrics[model_name] = {"input": 0, "cached": 0, "output": 0, "cost": 0.0}
+                    global_metrics[model_name]["input"] += tokens["input"]
+                    global_metrics[model_name]["cached"] += tokens["cached"]
+                    global_metrics[model_name]["output"] += tokens["output"]
+                    global_metrics[model_name]["cost"] += tokens["cost"]
+            
+            # Time stamp with the total single-paper cost, saved to tracking log
+            timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
+            log_lines.append(f"{paper_folder}: COMPLETED at {timestamp} | Total Cost: ${total_cost:.4f}\n")
+
             # Log completion
             with open(log_file, "a") as f:
-                f.write(f"{paper_folder}: COMPLETED at {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+                f.write("\n".join(log_lines))
 
         except Exception as e:
             print(f"  ❌ Error processing paper {paper_folder}: {str(e)}")
@@ -385,6 +508,43 @@ async def process_papers(
         print(f"❌ Failed papers: {', '.join(failed_papers)}")
     print(f"📝 Detailed log: {log_file}")
 
+    # Full run information for the end of the processing log file
+    # Executes once the whole stack of folders has finished processing
+    if global_metrics:
+        # Calculate the overall total costs and total tokens used across all files processed
+        overall_total_cost = sum(m["cost"] for m in global_metrics.values())
+        overall_total_tokens = sum(m["input"] + m["cached"] + m["output"] for m in global_metrics.values())
+        
+        # Title for readability
+        summary_lines = [
+            "\nFull Run Totals:"
+        ]
+        # Iterate through global_metrics to generate the final text lines for the log file
+        for model_key, m in global_metrics.items():
+            # Separate the combined key to identify the phase and model name strings
+            if "|" in model_key:
+                phase, model_name = model_key.split("|", 1)
+                model_display = f"{phase} Model: {model_name}"
+            else:
+                # Use the full key as the display name if the data format doesn't have the '|' splitting it
+                model_display = f"Model: {model_key}"
+                
+            # Format the metrics into an easy to read text block with all the usage information
+            summary_lines.append(
+                f"{model_display}\n"
+                f"New Input Tokens: {m['input']}\n"
+                f"Cached Input Tokens: {m['cached']}\n"
+                f"Output Tokens: {m['output']}\n"
+                f"Overall Cost: ${m['cost']:.4f}\n"
+            )
+        
+        # Add the combined run totals to the end of the summary
+        summary_lines.append(f"Total Tokens Combined: {overall_total_tokens}")
+        summary_lines.append(f"Total Cost Combined: ${overall_total_cost:.4f}\n")
+        
+        # Write the summary into the log file at the end of the run
+        with open(log_file, "a") as f:
+            f.write("\n".join(summary_lines))
 
 def main(argv=None):
     """Main entry point."""

--- a/src/metabeeai/metabeeai_llm/llm_pipeline.py
+++ b/src/metabeeai/metabeeai_llm/llm_pipeline.py
@@ -1,10 +1,10 @@
 import argparse
 import asyncio
+import copy
 import json
 import os
 import sys
 import time
-import copy
 
 import yaml
 
@@ -47,7 +47,8 @@ def _get_questions():
         questions_path = os.path.join(script_dir, "questions.yml")
 
         with open(questions_path, "r") as file:
-            # Extract the questions ('QUESTIONS') dictionary to prevent double-wrapping if it exists, otherwise use the whole config as the questions dictionary
+            # Extract the questions ('QUESTIONS') dictionary to prevent double-wrapping if it exists
+            # Otherwise use the whole config as the questions dictionary
             config = yaml.safe_load(file)
             _QUESTIONS = config.get("QUESTIONS", config)
 
@@ -80,7 +81,7 @@ async def get_answer(question_text, json_path, relevance_model=None, answer_mode
             # Pass total question cost to the pipeline for logging (will be popped before saving to answers.json)
             "cost": result.get("cost", 0.0),
             # Pass aggregated token metrics to the pipeline for logging (will be popped before saving to answers.json)
-            "metrics": result.get("metrics", {})
+            "metrics": result.get("metrics", {}),
         }
     else:
         # Fallback if result is not a dict
@@ -88,10 +89,12 @@ async def get_answer(question_text, json_path, relevance_model=None, answer_mode
             "answer": str(result) if result else "",
             "reason": "Answer generated from available information",
             "chunk_ids": [],
-            # Safety fallback - pass zero cost so the logging loop doesn't crash (still popped before saving to answers.json)
+            # Safety fallback - pass zero cost so the logging loop doesn't crash
+            # (still popped before saving to answers.json)
             "cost": 0.0,
-            # Safety fallback - pass empty metrics dictionary so the logging loop doesn't crash (still popped before saving to answers.json)
-            "metrics": {}
+            # Safety fallback - pass empty metrics dictionary so the logging loop doesn't crash
+            # (still popped before saving to answers.json)
+            "metrics": {},
         }
 
 
@@ -138,18 +141,18 @@ async def process_question_tree(tree, json_path, context=None, relevance_model=N
                     list_result = await format_to_list_async(question_of_the_list, answer["answer"])
                     list_items = list_result["answer"]
                     result[key] = {}
-                    
+
                     # Preserve the parent list costs so extract_metrics can see them
                     # Sum the costs of both finding the list and formatting it into an array
                     total_list_cost = answer.get("cost", 0.0) + list_result.get("cost", 0.0)
-                    
+
                     # Copy the original list token metrics into the combined run metrics tracker
                     combined_metrics = copy.deepcopy(answer.get("metrics", {}))
                     if list_result and "usage_details" in list_result:
                         usage = list_result["usage_details"]
                         m_name = usage.get("model", "unknown")
                         metric_key = f"Answering|{m_name}"
-                        
+
                         # Initialise counters for the model if it's the first time seeing it in this block
                         if metric_key not in combined_metrics:
                             combined_metrics[metric_key] = {"input": 0, "cached": 0, "output": 0, "cost": 0.0}
@@ -163,7 +166,7 @@ async def process_question_tree(tree, json_path, context=None, relevance_model=N
                     result[key]["_list_metadata"] = {
                         "answer": "List discovery metadata",
                         "cost": total_list_cost,
-                        "metrics": combined_metrics
+                        "metrics": combined_metrics,
                     }
 
                     for item in list_items:
@@ -245,6 +248,7 @@ def merge_json_in_the_folder(folder_path, overwrite=False):
     with open(folder_path + "merged.json", "w") as f:
         json.dump(json_obj, f, indent=2)
 
+
 def extract_metrics(answers_dict, prefix=""):
     """
     Iterates through the answers dictionary to extract costs and model metrics, removing them from the dictionary.
@@ -253,7 +257,7 @@ def extract_metrics(answers_dict, prefix=""):
     costs = {}
     metrics = {}
     total = 0.0
-    
+
     # Handle lists if the top-level question yml is an array
     if isinstance(answers_dict, list):
         for i, item in enumerate(answers_dict):
@@ -263,7 +267,6 @@ def extract_metrics(answers_dict, prefix=""):
                 metrics.update(sub_metrics)
                 total += sub_total
         return costs, metrics, total
-
 
     # Use list() to modify the dictionary while looping
     for key in list(answers_dict.keys()):
@@ -278,7 +281,7 @@ def extract_metrics(answers_dict, prefix=""):
             else:
                 # If it's a nested category dictionary, go one layer deeper
                 sub_costs, sub_metrics, sub_total = extract_metrics(value, prefix=f"{prefix}{key}.")
-                
+
                 # Merge the numbers found in the sub-category into the main tracking dictionaries
                 costs.update(sub_costs)
                 metrics.update(sub_metrics)
@@ -295,13 +298,14 @@ def extract_metrics(answers_dict, prefix=""):
                     # Go one layer deeper into the list items
                     # Adds [i] to the prefix to track which list item the cost belongs to
                     sub_costs, sub_metrics, sub_total = extract_metrics(item, prefix=f"{prefix}{key}[{i}].")
-                    
+
                     # Merge the numbers found in the sub-category into the main tracking dictionaries
                     costs.update(sub_costs)
                     metrics.update(sub_metrics)
                     total += sub_total
-                    
+
     return costs, metrics, total
+
 
 async def process_papers(
     base_dir=None,
@@ -369,10 +373,10 @@ async def process_papers(
     print(f"📁 Papers directory: {base_dir}")
     print(f"📝 Progress log: {log_file}")
     print("=" * 60)
-    
+
     # Initialise the global metrics dictionary to hold the total token and cost counts across all files in the run
     global_metrics = {}
-    
+
     for paper_folder in paper_folders:
         paper_path = os.path.join(base_dir, paper_folder)
 
@@ -472,7 +476,7 @@ async def process_papers(
             for q_key, q_cost in costs.items():
                 # Format individual cost metrics for clear reading in the log file
                 log_lines.append(f"- {q_key}: ${q_cost:.4f}")
-                
+
                 # Collect token usage totals into global_metrics for the final summary
                 q_m = question_metrics.get(q_key, {})
                 for model_name, tokens in q_m.items():
@@ -482,9 +486,9 @@ async def process_papers(
                     global_metrics[model_name]["cached"] += tokens["cached"]
                     global_metrics[model_name]["output"] += tokens["output"]
                     global_metrics[model_name]["cost"] += tokens["cost"]
-            
+
             # Time stamp with the total single-paper cost, saved to tracking log
-            timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
             log_lines.append(f"{paper_folder}: COMPLETED at {timestamp} | Total Cost: ${total_cost:.4f}\n")
 
             # Log completion
@@ -514,11 +518,9 @@ async def process_papers(
         # Calculate the overall total costs and total tokens used across all files processed
         overall_total_cost = sum(m["cost"] for m in global_metrics.values())
         overall_total_tokens = sum(m["input"] + m["cached"] + m["output"] for m in global_metrics.values())
-        
+
         # Title for readability
-        summary_lines = [
-            "\nFull Run Totals:"
-        ]
+        summary_lines = ["\nFull Run Totals:"]
         # Iterate through global_metrics to generate the final text lines for the log file
         for model_key, m in global_metrics.items():
             # Separate the combined key to identify the phase and model name strings
@@ -528,7 +530,7 @@ async def process_papers(
             else:
                 # Use the full key as the display name if the data format doesn't have the '|' splitting it
                 model_display = f"Model: {model_key}"
-                
+
             # Format the metrics into an easy to read text block with all the usage information
             summary_lines.append(
                 f"{model_display}\n"
@@ -537,14 +539,15 @@ async def process_papers(
                 f"Output Tokens: {m['output']}\n"
                 f"Overall Cost: ${m['cost']:.4f}\n"
             )
-        
+
         # Add the combined run totals to the end of the summary
         summary_lines.append(f"Total Tokens Combined: {overall_total_tokens}")
         summary_lines.append(f"Total Cost Combined: ${overall_total_cost:.4f}\n")
-        
+
         # Write the summary into the log file at the end of the run
         with open(log_file, "a") as f:
             f.write("\n".join(summary_lines))
+
 
 def main(argv=None):
     """Main entry point."""
@@ -570,7 +573,7 @@ def main(argv=None):
         type=str,
         nargs="+",
         default=None,
-        help=("Specific paper IDs to process (e.g., 283C6B42 3ZHNVADM). " "If not specified, all folders will be processed."),
+        help=("Specific paper IDs to process (e.g., 283C6B42 3ZHNVADM). If not specified, all folders will be processed."),
     )
     parser.add_argument(
         "--start",


### PR DESCRIPTION
Changes to json_multistage_qa and llm_pipeline to introduce a cost and token counting system. Uses LiteLLM's catalogue to find the costs for the model used, with a hardcoded fallback if the model is not found (currently includes GPT 4 models: 4o and 4o mini, and GPT 5 models: nano, mini, 5 and 5.1). 

Outputs (found in processing_log):
- Individual question costs, total paper costs (with paper completion day/time)
- Full run breakdown: total tokens and costs, separated into retrieval and answering model tokens/costs
- Final metrics: a final total token count and total run cost at the very end of the file.